### PR TITLE
fix(order-history): show 3 cards per row on large screens

### DIFF
--- a/client/src/helpers/tokenValidation.js
+++ b/client/src/helpers/tokenValidation.js
@@ -3,9 +3,8 @@ import { isAuthorized } from './authorization';
 
 const isValid = () => {
   const { cookie } = document;
-  const token = cookie.split('jwt-token=');
-  if (token.length === 2) {
-    const jwtToken = token[1];
+  const jwtToken = cookie.split('jwt-token=')[1];
+  if (jwtToken) {
     const decodedToken = jwtDecode(jwtToken);
     const { exp } = decodedToken;
     if (exp > Math.floor(new Date().getTime() / 1000)) {      
@@ -13,7 +12,7 @@ const isValid = () => {
     } 
     return false;
   }
-  return true;
+  return false;
 };
 
 /**

--- a/client/src/store/store.js
+++ b/client/src/store/store.js
@@ -8,8 +8,8 @@ import { tokenValidator } from '../helpers/tokenValidation';
 
 const initialState = {};
 const middlewares = process.env.NODE_ENV === 'production' 
-  ? [thunk] 
-  : [thunk, reduxImmutableStateInvariant()];
+  ? [tokenValidator, thunk] 
+  : [tokenValidator, thunk, reduxImmutableStateInvariant()];
 /**
  * @export
  * @param {any} {}

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -13,3 +13,6 @@ $color-green: #51A803;
 $color-red: red;
 
 $font-family-regular: "DINPro-Regular";
+
+$small_screen: 20em;
+$large_screen: 64em;

--- a/client/src/styles/components/_mealcard.scss
+++ b/client/src/styles/components/_mealcard.scss
@@ -1,10 +1,17 @@
 .card-container {
   max-height: 320px;
-  min-width: 340px;	
-  border-radius: 2px;	
+  border-radius: 2px;
   background-color: $color-white;
-  margin: 32px 25px;
+  margin: 32px 20px;
   border: 1px solid $color-light-grey;
+
+  @media (min-width: $small_screen) {
+    min-width: 40%;	
+  }
+
+  @media (min-width: $large_screen) {
+    min-width: 28%;
+  }
 
   &:hover {
     box-shadow: 3px 3px 5px $color-light-grey;
@@ -43,7 +50,7 @@
   }
 
   .card-details {
-    margin: 16px 20px;
+    margin: 16px 15px;
 
     .main{
       border-bottom: 1px solid $color-light-grey;


### PR DESCRIPTION
**What does this PR do?**
- Show 3 meal cards per row when viewing order history page on large screen ( > 64em)
- Show 2 meal cards per row when viewing order history page on medium screen/high res tablets (> 20em and < 64em )
- Show 1 meal card per row when viewing order history on small screens/low res tabs ( >= 20em)

**What are the relevant pivotal tracker stories?**
[#159305054](https://www.pivotaltracker.com/story/show/159305054)

**Screenshot?**
<img width="1680" alt="screen shot 2018-07-25 at 4 17 51 pm" src="https://user-images.githubusercontent.com/8871565/43210619-81f02f44-9027-11e8-9306-849d11b8395a.png">
<img width="1680" alt="screen shot 2018-07-25 at 4 16 02 pm" src="https://user-images.githubusercontent.com/8871565/43210049-0da46304-9026-11e8-9334-1e7108178e65.png">
<img width="1680" alt="screen shot 2018-07-25 at 4 16 23 pm" src="https://user-images.githubusercontent.com/8871565/43210066-188acdee-9026-11e8-9550-d8e2d43bde0e.png">

