### PR TITLE
#163082478 Fix Admin export order history take

### DIFF
--- a/client/src/components/Admin/OrderHistory/ExportOrders.jsx
+++ b/client/src/components/Admin/OrderHistory/ExportOrders.jsx
@@ -63,9 +63,11 @@ export class ExportOrders extends Component {
           )}
 
           <div className="table-header">
-            <div className="custom-col-4">Order Number</div>
-            <div className="custom-col-3">Owner</div>
-            <div className="custom-col-5">Order Description</div>
+            <div className="custom-col-4">Name</div>
+            <div className="custom-col-2">Order Date</div>
+            <div className="custom-col-2">Collection Date</div>
+            <div className="custom-col-4">Order Description</div>
+            <div className="custom-col-2">Status</div>
           </div>
 
           { orders && orders.map((order) => this.renderOrder(order))}

--- a/client/src/components/Admin/OrderHistory/Index.jsx
+++ b/client/src/components/Admin/OrderHistory/Index.jsx
@@ -92,7 +92,8 @@ export class OrderHistory extends Component {
               <Fragment>
                 <div className="table-header">
                   <div className="custom-col-4">Name</div>
-                  <div className="custom-col-2">Date</div>
+                  <div className="custom-col-2">Order Date</div>
+                  <div className="custom-col-2">Collection Date</div>
                   <div className="custom-col-4">Order Description</div>
                   <div className="custom-col-2">Status</div>
                 </div>

--- a/client/src/components/Admin/OrderHistory/OrderCard.jsx
+++ b/client/src/components/Admin/OrderHistory/OrderCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 
-const OrderCard = ({ order: { userId, dateBookedFor, mealItems, orderStatus } }) => {
+const OrderCard = ({ order: { user, dateBooked, dateBookedFor, mealItems, orderStatus } }) => {
   return (
   <div className={
       `table-body ${orderStatus === 'collected' ?
@@ -12,7 +12,10 @@ const OrderCard = ({ order: { userId, dateBookedFor, mealItems, orderStatus } })
     <div className="table-row">
       <div className="custom-row">
         <div className="custom-col-4">
-          { userId }
+          { user }
+        </div>
+        <div className={`custom-col-${orderStatus ? 2 : 3}`}>
+          { format(dateBooked, 'YYYY-MM-DD') }
         </div>
         <div className={`custom-col-${orderStatus ? 2 : 3}`}>
           { format(dateBookedFor, 'YYYY-MM-DD') }
@@ -38,9 +41,10 @@ const OrderCard = ({ order: { userId, dateBookedFor, mealItems, orderStatus } })
 
 OrderCard.propTypes = {
   order: PropTypes.shape({
-    userId: PropTypes.string.isRequired,
-    dateBookedFor: PropTypes.string.isRequired,
-    mealItems: PropTypes.array.isRequired
+  user: PropTypes.string.isRequired,
+  dateBooked: PropTypes.string.isRequired,
+  dateBookedFor: PropTypes.string.isRequired,
+  mealItems: PropTypes.array.isRequired
   })
 };
 

--- a/client/src/components/Admin/OrderHistory/OrdersHeader.jsx
+++ b/client/src/components/Admin/OrderHistory/OrdersHeader.jsx
@@ -5,15 +5,18 @@ import { CSVLink } from "react-csv";
 import Filter from './Filter';
 
 const headers = [
-  { label: "ID", key: "id" },
-  { label: "Owner", key: "owner" },
-  { label: "OrderDescription", key: "orderDescription" }
+  { label: "Name", key: "user" },
+  { label: "Order Date", key: "dateBooked" },
+  { label: "Collection Date", key: "dateBookedFor" },
+  { label: "Main Meal", key: "mealItems[0].name" },
+  { label: "Side Meal", key: "mealItems[1].name"},
+  { label: "Protein", key: "mealItems[2].name"},
+  { label: "Status", key: "orderStatus" }
 ];
 
 export class OrdersHeader extends Component {
   render() {
     const { title, orders, redirectToExport, svg, type } = this.props;
-
     return (
       <header className="orders-header">
         <div className="left-section">

--- a/client/src/styles/components/admin/_orders.scss
+++ b/client/src/styles/components/admin/_orders.scss
@@ -62,6 +62,7 @@ $filter-btn-style: (
 
     .export-btn-2 {
       margin-top: px-to-rem(10px);
+      margin-left: px-to-rem(10px);
     }
 
     .filter-btn, .export-btn-2 {


### PR DESCRIPTION
#### What does this PR do?

- Adds a new column to the order history table for when an order was made
- Implements the export functionality

#### Description of Task to be completed?

- add a column for when the order was made
- implement the export order history functionality

#### How should this be manually tested?

- Clone the repository [here](https://github.com/andela/AndelaEatsUI.git)
-  cd into AndelaEatsUI and checkout to this branch `bg-fix-order-table-163082478`
- run these commands `npm run build` and `npm run dev` 
- Log in as an admin, and from the admin dashboard, click on `Orders`. Then click on the `Export` button.

#### What are the relevant pivotal tracker stories?
- [#163082478](https://www.pivotaltracker.com/story/show/163082478)

#### Background Context

#### Screenshots (If Applicable)
