### PR TITLE
#163282740 Fix Admin should be able to edit a meal item

### DIFF
--- a/client/src/actions/admin/adminUserAction.js
+++ b/client/src/actions/admin/adminUserAction.js
@@ -33,7 +33,6 @@ export const addAdminUser = (message, type) => ({
         dispatch(addAdminUser(msg, ADD_ADMIN_USER_SUCCESS));
       })
       .catch((error) => {
-        console.log(error);
         error = error.response ? error.response.data.msg : 'Invalid Email Address entered!';
         toastError(error);
         dispatch(addAdminUser(error, ADD_ADMIN_USER_FAILURE));

--- a/client/src/actions/admin/mealItemsAction.js
+++ b/client/src/actions/admin/mealItemsAction.js
@@ -152,8 +152,9 @@ export const editMealItem = (mealItemId, formData) => dispatch => {
     if (error) { throw error; } else {
       const { file, dataurl, ...rest } = formData;
       const reqdata = { ...rest, image: url };
+
       return (
-        axios.put(`${apiBaseUrl}/meal-items/${mealItemId}`, reqdata)
+        axios.patch(`${apiBaseUrl}/meal-items/${mealItemId}`, reqdata)
           .then(response => {
             const { mealItem } = response.data.payload;
             toastSuccess("Meal item updated successfully");

--- a/client/src/components/Admin/Meals/MealModal/Index.jsx
+++ b/client/src/components/Admin/Meals/MealModal/Index.jsx
@@ -93,14 +93,17 @@ class MealModal extends Component {
       this.state,
       this.mealTypes
     );
-    
+
     if (Array.isArray(formData)) {
       this.props.setAddMealErrors(formData);
     } else {
-      if (edit) {
+      if (edit && formData.mealName !== this.props.mealDetails.name) {
+        return this.props.editMealItem(mealDetails.id, formData);
+      } else {
+        formData.mealName = "";
         return this.props.editMealItem(mealDetails.id, formData);
       }
-      
+
       this.props.addMealItem(formData);
     }
   }

--- a/client/src/components/Admin/Users/Users.jsx
+++ b/client/src/components/Admin/Users/Users.jsx
@@ -11,10 +11,6 @@ import { createAdminUser } from '../../../actions/admin/adminUserAction';
 
 export class Users extends Component {
 
-  componentWillReceiveProps(nextProps) {
-    console.log('Next Props: ', nextProps);
-  }
-
   handleSubmit = (event) => {
     event.preventDefault();
     let userData = {


### PR DESCRIPTION
#### What does this PR do?

- Admin should be able to edit a meal item without editing the name

#### Description of Task to be completed?

- improve the Edit Meal Item functionality so that an admin
can edit a meal without having to edit the meal item name

#### How should this be manually tested?

- Clone the repository [here](https://github.com/andela/AndelaEatsUI.git)
-  cd into AndelaEatsUI and checkout to this branch `bg-admin-meal-edit-163282740`
- run these commands `npm run build` and `npm run dev` 
- Log in as an admin, and from the admin dashboard, click on `Menus` and navigate to the `Meals` tab. Then click on the `Edit` button on any meal card and edit any other field other than the name.

#### What are the relevant pivotal tracker stories?
- [#163282740](https://www.pivotaltracker.com/story/show/163282740)

#### Background Context

- Previously, when an admin would edit a Meal item without changing the meal name, the app would throw a duplication error.

#### Screenshots (If Applicable)
N/A
