### PR TITLE
#163511218 Display available menus to the user

### DIFF
--- a/client/src/actions/admin/mealItemsAction.js
+++ b/client/src/actions/admin/mealItemsAction.js
@@ -86,6 +86,7 @@ export const addMealItem = formData => dispatch => {
         axios.post(`${apiBaseUrl}/meal-items/`, reqdata)
           .then((response) => {
             const { mealItem } = response.data.payload;
+            toastSuccess('Meal successfully created');
             dispatch(addMealItemSuccess(mealItem));
             dispatch(showMealModalAction(false, false));
             dispatch(setAddMealLoading(false));

--- a/client/src/components/Admin/Meals/MealModal/Index.jsx
+++ b/client/src/components/Admin/Meals/MealModal/Index.jsx
@@ -97,13 +97,14 @@ class MealModal extends Component {
     if (Array.isArray(formData)) {
       this.props.setAddMealErrors(formData);
     } else {
-      if (edit && formData.mealName !== this.props.mealDetails.name) {
-        return this.props.editMealItem(mealDetails.id, formData);
-      } else {
-        formData.mealName = "";
-        return this.props.editMealItem(mealDetails.id, formData);
+      if (edit) {
+        const mealData = {
+          ...formData,
+          mealName: (this.props.mealDetails.name === formData.mealName)
+            ? '' : formData.mealName
+        };
+        this.props.editMealItem(mealDetails.id, mealData);
       }
-
       this.props.addMealItem(formData);
     }
   }
@@ -298,7 +299,9 @@ MealModal.propTypes = {
   isLoading: PropTypes.bool,
   addBtnDisabled: PropTypes.bool,
   setAddMealErrors: PropTypes.func.isRequired,
-  mealDetails: PropTypes.shape({}),
+  mealDetails: PropTypes.shape({
+    name: PropTypes.string.isRequired
+  }),
   editMealItem: PropTypes.func,
 };
 

--- a/client/src/components/Admin/Menus/MenuTable.jsx
+++ b/client/src/components/Admin/Menus/MenuTable.jsx
@@ -1,0 +1,180 @@
+import React, { Component } from "react";
+import { connect } from 'react-redux';
+import {
+  func, shape, arrayOf, bool, any
+} from 'prop-types';
+import moment from 'moment';
+import formatMealItems, {
+  formatDate, isStartgreaterThanEnd
+} from '../../../helpers/formatMealItems';
+
+import { formatMenuItemDate } from '../../../helpers/menusHelper';
+import Loader from "../../common/Loader/Loader";
+import EmptyContent from '../../common/EmptyContent';
+
+
+/**
+ *
+ *
+ * @description MenusTable Component
+ *
+ * @class MenuTable
+ * @extends Component
+ */
+class MenuTable extends Component {
+  /**
+   *
+   * @description render side and protein listing
+   *
+   * @param { Array } itemsAvailable
+   * @param { Integer } optionsCanPick
+   *
+   * @memberof Menus
+   *
+   * @returns { JSX }
+   */
+  renderProteinSideItems = (itemsAvailable, optionsCanPick) => (
+    <div className="custom-col-6 clearfix">
+      <span className="side-pick-count">
+        { optionsCanPick }
+      </span>
+      { this.commaJoinComplementryItems(itemsAvailable.map(item => ({
+        value: item.id, label: item.name
+      }))) }
+    </div>
+  );
+
+  /**
+   *
+   *
+   * @description joins strings
+   *
+   * @param { Array } array
+   * @param { Stirng } key
+   *
+   * @returns { String }
+   *
+   * @memberof Menus
+   */
+  commaJoinComplementryItems = (array) => (
+    array.map(item => item.label).join(', ')
+  );
+
+  /**
+   * @description generate menu rows
+   *
+   * @returns { Array }
+   *
+   * @memberof MenuTable
+   */
+  renderRows = () => {
+    const { menuList } = this.props.menus;
+    return menuList.map(menuItem => {
+      const {
+        mainMealId,
+        id,
+        mainMeal,
+        mealPeriod,
+        sideItems,
+        proteinItems,
+        allowedSide,
+        allowedProtein,
+        date,
+        vendorEngagementId
+      } = menuItem;
+      const vendorList = this.props.menus.vendorEngagements
+        ? this.props.menus.vendorEngagements : [];
+      const menuVendor = vendorList
+        .filter(vendor => vendor.vendorId === vendorEngagementId)[0];
+      return (
+        <div key={id} className="ct-row">
+          <div className="ct-wrap">
+            <div className="custom-col-5">
+              { formatMenuItemDate(date) }
+            </div>
+            <div className="custom-col-5">
+              {menuVendor ? menuVendor.vendor.name : ''}
+            </div>
+            <div className="custom-col-4">{mainMeal.name}</div>
+            { this.renderProteinSideItems(
+              proteinItems,
+              allowedProtein
+            )}
+
+            { this.renderProteinSideItems(
+              sideItems,
+              allowedSide
+            )}
+
+            {!this.props.preview ? (
+              <div className="custom-col-5 option">
+                <div onClick={() => this.props.showAddModal(menuItem, true)}>
+                  <span className="edit-menu">Edit</span>
+                </div>
+
+                <div onClick={() => this.props.showDeleteModal(menuItem)}>
+                  <span className="delete-menu">Delete</span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      );
+    });
+  }
+
+  renderMenuBody = () => (
+    <React.Fragment>
+      {this.props.preview
+        ? <h3 className="card-header"> Available Menus</h3>
+        : null}
+      <div className="custom-table">
+        {this.props.menus.menuList.length
+          ? (
+            <React.Fragment>
+              <div className="ct-header">
+                <div className="custom-col-5">Date</div>
+                <div className="custom-col-5">Vendor</div>
+                <div className="custom-col-4">Main Meal</div>
+                <div className="custom-col-6">Protein</div>
+                <div className="custom-col-6">Side</div>
+                { !this.props.preview
+                  ? <div className="custom-col-5">Options</div>
+                  : null}
+              </div>
+              <div className="ct-body">{this.renderRows()}</div>
+            </React.Fragment>) : <EmptyContent message="No menu available" />}
+      </div>
+    </React.Fragment>
+  )
+
+
+  render() {
+    const { isLoading } = this.props.menus;
+    return (
+      <div className="menu-table-row">
+        { isLoading
+          ? <Loader />
+          : this.renderMenuBody()
+        }
+      </div>
+    );
+  }
+}
+
+MenuTable.propTypes = {
+  menus: shape({
+    isLoading: bool.isRequired,
+    isDeleting: bool.isRequired,
+    menuList: arrayOf(shape({})),
+    error: shape({
+      status: bool,
+      message: any
+    })
+  }),
+  preview: bool,
+  showAddModal: func,
+  showDeleteModal: func,
+};
+
+export default MenuTable;

--- a/client/src/helpers/mealsHelper.js
+++ b/client/src/helpers/mealsHelper.js
@@ -76,9 +76,7 @@ export const findUpdatedIndex = (prevState, updatedId) => (
 );
 
 export const setMealImage = (image) => (
-  image === 'google.com' || image.match(/^image.+$/)
-    ? defMealImage
-    : image
+  !image ? defMealImage : image
 );
 
 export const mealImageUpload = (file, dataurl, callback) => {

--- a/client/src/styles/components/_order.scss
+++ b/client/src/styles/components/_order.scss
@@ -1,18 +1,22 @@
 .orders-wrapper {
   h3 {
     font-weight: 700;
-    color: $color-dark-gray;
     font-size: 21px;
     line-height: 27px;
+    color:$color-blue;
+  }
+  .menu-container {
+    padding: 10px;
   }
 
 .orders-container {
-  height: auto;    
+  height: auto;
   width: 1080px; 
   border: 1px solid $color-light-gray;    
   background-color: $color-white;
   display: flex;
   flex-direction: row;
+  margin: 4px;
 
   .date-wrapper {
     flex: 0 0 280px;
@@ -21,7 +25,6 @@
 
     h3 {
       text-align: center;
-      color: $color-medium-gray;
     }
 
     ul {

--- a/client/src/styles/components/_tabs.scss
+++ b/client/src/styles/components/_tabs.scss
@@ -13,6 +13,10 @@ _tabs.scss
   margin-right: 3rem;
   padding-right: 5rem;
   cursor: pointer;
+  transition: border-bottom 0.2s
+}
+.tab-list-item:hover {
+  border-bottom: 1px solid $color-blue;
 }
 
 .tab-list-active {
@@ -22,6 +26,6 @@ _tabs.scss
   border-style: solid solid;
   border-color: rgb(221, 221, 221) rgb(221, 221, 221);
   border-image: initial;
-  border-top: 2px solid rgb(52, 152, 219);
+  border-top: 2px solid $color-blue;
   border-bottom: 0px;
 }

--- a/client/src/styles/components/admin/_menus.scss
+++ b/client/src/styles/components/admin/_menus.scss
@@ -83,21 +83,6 @@
           .ct-wrap {
             width: 95%;
             margin: 0 auto;
-            
-            .side-pick-count {
-              display: block;
-              width: 20px;
-              height: 20px;
-              float: left;
-              background: $color-blue;
-              color: white;
-              border-radius: 50%;
-              font-size: 13px;
-              overflow: hidden;
-              text-align: center;
-              padding-top: 1px;
-              margin-right: 10px;
-            }
 
             &:last-child {
               a {
@@ -224,4 +209,35 @@
   &:hover {
     text-decoration: underline solid $color-red;
   }
+}
+
+.menu-table-row {
+  background: #F4F8F9;
+  width: 1080px;
+  margin: 4px;
+}
+
+.card-header {
+  padding-left: 20px;
+  width: 20%;
+  margin-top: 30px;
+  transition: border-bottom 0.2s;
+}
+.card-header:hover {
+   border-bottom: 1px solid $color-blue;
+}
+
+.side-pick-count {
+  display: block;
+  width: 20px;
+  height: 20px;
+  float: left;
+  background: $color-blue;
+  color: white;
+  border-radius: 50%;
+  font-size: 13px;
+  overflow: hidden;
+  text-align: center;
+  padding-top: 1px;
+  margin-right: 10px;
 }

--- a/client/src/tests/components/Admin/Menus/Index.test.js
+++ b/client/src/tests/components/Admin/Menus/Index.test.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
 import { Menus } from '../../../../components/Admin/Menus/Index';
 import menu from '../../../__mocks__/mockMenuList';
 import Loader from '../../../../components/common/Loader/Loader';
@@ -36,7 +35,8 @@ describe('Admin: Menu Component', () => {
     fetchMealItems: jest.fn(),
     createMenu: jest.fn(() => Promise.resolve()),
     editMenu: jest.fn(() => Promise.resolve()),
-    deleteMenuItem: jest.fn(() => Promise.resolve())
+    deleteMenuItem: jest.fn(() => Promise.resolve()),
+    isLoading: false,
   };
 
   beforeEach(() => {

--- a/client/src/tests/components/Orders/Orders.test.js
+++ b/client/src/tests/components/Orders/Orders.test.js
@@ -7,7 +7,7 @@ import ConnectedOrders, { Orders } from '../../../components/Order/Orders';
 import { mockMenu } from '../../helpers/mockOrders';
 
 const props = {
-  menus: mockMenu,
+  userMenus: mockMenu,
   match: {
     url: 'http:abc.css'
   },
@@ -81,7 +81,7 @@ describe('ConnectedOrders test', () => {
   it('should render correctly', () => {
     const store = mockStore({
       upcomingMenus: {
-        menus: [], 
+        userMenus: [],
         acc1: {},
         acc2: {},
         mainMeal: {},


### PR DESCRIPTION

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

#### What does this PR do?
- Enables a user to view all the available menus.
#### Description of Task to be completed?
 - Add menu table component
- Display menus on normal user's page
#### How should this be manually tested?
- Log into the application
- On the the user's landing page you should see all the available menus
#### What are the relevant pivotal tracker stories?
- [#163511218](https://www.pivotaltracker.com/story/show/163511218)

#### Background Context
N/A
#### Screenshots (If Applicable)
<img width="1412" alt="screenshot 2019-01-30 at 16 33 59" src="https://user-images.githubusercontent.com/39955261/51984654-eebf4c80-24ac-11e9-8d3f-d5b1cea9df1f.png">

