### PR TITLE
Fix: Update APT sources before running deployment scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,15 @@ jobs:
           name: install dependencies 
           command: cd client/ && npm install
       - run:
+          name: Update APT sources list
+          command: |
+            sudo rm /etc/apt/sources.list
+            echo "deb http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
+            echo "deb-src http://archive.debian.org/debian/ jessie-backports main" | sudo tee -a /etc/apt/sources.list
+            echo "Acquire::Check-Valid-Until false;" | sudo tee -a /etc/apt/apt.conf.d/10-nocheckvalid
+            echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' | sudo tee -a /etc/apt/preferences.d/10-archive-pin
+            sudo apt-get update
+      - run:
           name: Deploy application to environment
           command: |
             chmod +x scripts/deploy.sh && ./scripts/deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,4 +63,5 @@ workflows:
                 - staging
                 - develop
                 - /(release|hotfix)\/v[0-9].[0-9].[0-9]/
+                - ch-fix-problem-with-apt-CCI
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,5 +63,4 @@ workflows:
                 - staging
                 - develop
                 - /(release|hotfix)\/v[0-9].[0-9].[0-9]/
-                - ch-fix-problem-with-apt-CCI
 


### PR DESCRIPTION
#### What does this PR do?
- Fixes an issue whereby jessie-updates are missing from the mirror that we get redirected to on CircleCI

#### Description of Task to be completed?
- Fix an issue where deployments stalled due to missing `debian-jessie` packages.

#### How should this be manually tested?
- Trust me, it works 😎 

#### Any background context you want to provide?
- A pull request should be made once a merge or a commit is made to `develop` or master branches.

#### What are the relevant pivotal tracker stories?
N/A

#### Postman Documentation
N/A

#### Screenshots (If applicable)