### PR TITLE
#166028205 Handle the error in the catch block of the addMealItem Action

### DIFF
--- a/client/src/actions/admin/mealItemsAction.js
+++ b/client/src/actions/admin/mealItemsAction.js
@@ -52,15 +52,21 @@ export const showMealModalAction = (show, edit) => ({
   payload: { show, edit }
 });
 
-export const setAddMealErrors = errors => dispatch => dispatch({
+export const setAddMealErrors = errors => ({
   type: SET_ADD_MEAL_ERRORS,
   payload: errors
+});
+
+export const addMealItemFailure = error => ({
+  type: EDIT_MEAL_ITEM_FAILURE,
+  payload: error
 });
 
 export const setAddMealLoading = loading => ({
   type: SET_ADD_MEAL_LOADING,
   payload: loading
 });
+
 
 export const addMealItemSuccess = mealItem => ({
   type: ADD_MEAL_ITEM_SUCCESS,
@@ -89,7 +95,9 @@ export const addMealItem = formData => dispatch => {
             dispatch(showMealModalAction(false, false));
             dispatch(setAddMealLoading(false));
           })
-          .catch((error) => {
+          .catch((err) => {
+            toastError("Meal name already exists, please try another.");
+            dispatch(addMealItemFailure(err));
             dispatch(setAddMealLoading(false));
           })
       );
@@ -148,10 +156,11 @@ export const editMealItemSuccess = (mealItemId, mealItem) => ({
 export const editMealItem = (mealItemId, formData) => dispatch => {
   dispatch(editMealItemLoading(true));
   return mealImageUpload(formData.file, formData.dataurl, (error, url) => {
-    if (error) { throw error; } else {
+    if (error) { 
+      throw error; 
+    } else {
       const { file, dataurl, ...rest } = formData;
       const reqdata = { ...rest, image: url };
-
       return (
         axios.patch(`/meal-items/${mealItemId}`, reqdata)
           .then(response => {
@@ -162,7 +171,7 @@ export const editMealItem = (mealItemId, formData) => dispatch => {
             dispatch(editMealItemLoading(false));
           })
           .catch(err => {
-            toastError("Meal item update failed");
+            toastError("Meal item update failed. Please try another meal name");
             dispatch(editMealItemFailure(err));
             dispatch(editMealItemLoading(false));
           })


### PR DESCRIPTION

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

#### What does this PR do?
Handle the error in the catch block of the addMealItem Action

#### Description of Task to be completed?
- Add toastError() to the catch block of the addMealItem action
- Dispatch a failure action

#### How should this be manually tested?
- Clone the repo
- Checkout to `bg-fix-add-meal-feedback-166028205`
- Run `npm run build`
- Run `npm run dev`
- Login and switch to admin mode
- Click `Manage Menus` menu
- Select `Meal` sub-menu
- Create a new meal using an existing name

#### What are the relevant pivotal tracker stories?
- [#166028205](https://www.pivotaltracker.com/story/show/166028205)

#### Background Context
- N/A

#### Screenshots (If Applicable)
<img width="1438" alt="Screen Shot 2019-05-15 at 1 09 05 PM" src="https://user-images.githubusercontent.com/25647480/57774593-db11bc00-7712-11e9-836f-14f5e6672258.png">

<img width="1434" alt="Screen Shot 2019-05-15 at 1 10 01 PM" src="https://user-images.githubusercontent.com/25647480/57774595-db11bc00-7712-11e9-8f2d-45c20c6e495a.png">
