### PR TITLE
#166028564 update meal item

### DIFF
--- a/client/src/actions/admin/mealItemsAction.js
+++ b/client/src/actions/admin/mealItemsAction.js
@@ -156,8 +156,8 @@ export const editMealItemSuccess = (mealItemId, mealItem) => ({
 export const editMealItem = (mealItemId, formData) => dispatch => {
   dispatch(editMealItemLoading(true));
   return mealImageUpload(formData.file, formData.dataurl, (error, url) => {
-    if (error) { 
-      throw error; 
+    if (error) {
+      throw error;
     } else {
       const { file, dataurl, ...rest } = formData;
       const reqdata = { ...rest, image: url };
@@ -171,11 +171,11 @@ export const editMealItem = (mealItemId, formData) => dispatch => {
             dispatch(editMealItemLoading(false));
           })
           .catch(err => {
-            toastError("Meal item update failed. Please try another meal name");
+            toastError(err.response.data.msg);
             dispatch(editMealItemFailure(err));
             dispatch(editMealItemLoading(false));
           })
       );
     }
-  }); 
+  });
 };

--- a/client/src/tests/actions/admin/mealItemsAction.test.js
+++ b/client/src/tests/actions/admin/mealItemsAction.test.js
@@ -74,7 +74,7 @@ describe('Admin::Meal Items Action', () => {
       moxios.stubRequest(`/meal-items/?page=1`, {
         status: 401,
       });
-  
+
       const expectedActions = [
         {
           type: FETCH_MEAL_ITEMS_LOADING,
@@ -89,9 +89,9 @@ describe('Admin::Meal Items Action', () => {
           payload: false,
         }
       ];
-  
+
       const store = mockStore({});
-  
+
       await store
         .dispatch(fetchMealItems())
         .then(() => {
@@ -189,12 +189,12 @@ describe('Admin::Meal Items Action', () => {
         });
       done();
     });
-  
+
     it('delete meal item failure', async (done) => {
       moxios.stubRequest(`/meal-items/${mealItems[0].id}`, {
         status: 401,
       });
-  
+
       const expectedActions = [
         {
           type: DELETE_MEAL_ITEM_LOADING,
@@ -209,9 +209,9 @@ describe('Admin::Meal Items Action', () => {
           payload: false,
         }
       ];
-  
+
       const store = mockStore({});
-  
+
       await store
         .dispatch(deleteMealItem(mealItems[0].id))
         .then(() => {
@@ -292,9 +292,12 @@ describe('Admin::Meal Items Action', () => {
       const store = mockStore({});
 
       moxios.stubRequest(`/meal-items/${mealItems[0].id}`, {
-        status: 500
+        status: 500,
+        response: {
+          msg: 'error'
+        }
       });
-      
+
       await store.dispatch(editMealItem(mealItems[0].id, formData))
         .then(() => {
           expect(store.getActions()).toEqual(expectedActions);


### PR DESCRIPTION
#### What does this PR do?
- return a more descriptive message on update meal failure

#### Description of Task to be completed?
- Update meal item fails in some cases

#### How should this be manually tested?
- Fetch branch `bg-update-meal-item-166028564`
- Start the server in `dev.` environment
- Log into the app
- Click the `Manage menu` on the menu bar.
- Click the `Meal` sub-menu 
- Edit any of the existing meal to `White rice` or any name you desire.

Perform CRUD operations on the users listed
#### What are the relevant pivotal tracker stories?
- [#166028564](https://www.pivotaltracker.com/story/show/166028564)

#### Background Context
- An error message `Meal update item failed` was being displayed when a legit meal item update failed.
- this was a backend error.
- I had a sync with a backend engineer and we resolved this, however, I thought it would also be good to return a well descriptive message on the frontend when the update failed hence actually raising this PR.

#### Screenshots
![update_meal](https://user-images.githubusercontent.com/25790450/57927808-d6d2d380-78b7-11e9-8d9e-4798da9b3725.gif)

