### PR TITLE
#166010381 Remove the Description Field from the Meal modal.

### DIFF
--- a/client/src/actions/admin/mealItemsAction.js
+++ b/client/src/actions/admin/mealItemsAction.js
@@ -13,19 +13,18 @@ import {
   DELETE_MEAL_ITEM_FAILURE,
   EDIT_MEAL_ITEM_FAILURE,
   EDIT_MEAL_ITEM_SUCCESS,
-  EDIT_MEAL_ITEM_LOADING
+  EDIT_MEAL_ITEM_LOADING,
 } from '../actionTypes';
 import { mealImageUpload } from '../../helpers/mealsHelper';
 
-
-export const fectchMealItemsLoading = isLoading => ({
+export const fectchMealItemsLoading = (isLoading) => ({
   type: FETCH_MEAL_ITEMS_LOADING,
   payload: isLoading,
 });
 
-export const fetchMealItemsFailure = error => ({
+export const fetchMealItemsFailure = (error) => ({
   type: FETCH_MEAL_ITEMS_FAILURE,
-  payload: error
+  payload: error,
 });
 
 export const fetchMealItemsSuccess = (mealItems, pagination) => ({
@@ -33,9 +32,10 @@ export const fetchMealItemsSuccess = (mealItems, pagination) => ({
   payload: { pagination, mealItems },
 });
 
-export const fetchMealItems = (page = 1) => dispatch => {
+export const fetchMealItems = (page = 1) => (dispatch) => {
   dispatch(fectchMealItemsLoading(true));
-  return axios.get(`/meal-items/?page=${page}`)
+  return axios
+    .get(`/meal-items/?page=${page}`)
     .then((response) => {
       const { meta: pagination, mealItems } = response.data.payload;
       dispatch(fetchMealItemsSuccess(mealItems, pagination));
@@ -49,35 +49,32 @@ export const fetchMealItems = (page = 1) => dispatch => {
 
 export const showMealModalAction = (show, edit) => ({
   type: SHOW_MEAL_MODAL,
-  payload: { show, edit }
+  payload: { show, edit },
 });
 
-export const setAddMealErrors = errors => ({
+export const setAddMealErrors = (errors) => ({
   type: SET_ADD_MEAL_ERRORS,
-  payload: errors
+  payload: errors,
 });
 
-export const addMealItemFailure = error => ({
+export const addMealItemFailure = (error) => ({
   type: EDIT_MEAL_ITEM_FAILURE,
-  payload: error
+  payload: error,
 });
 
-export const setAddMealLoading = loading => ({
+export const setAddMealLoading = (loading) => ({
   type: SET_ADD_MEAL_LOADING,
-  payload: loading
+  payload: loading,
 });
 
-
-export const addMealItemSuccess = mealItem => ({
+export const addMealItemSuccess = (mealItem) => ({
   type: ADD_MEAL_ITEM_SUCCESS,
-  payload: mealItem
+  payload: mealItem,
 });
 
-export const showMealModal = (show, edit) => dispatch => dispatch(
-  showMealModalAction(show, edit)
-);
+export const showMealModal = (show, edit) => (dispatch) => dispatch(showMealModalAction(show, edit));
 
-export const addMealItem = formData => dispatch => {
+export const addMealItem = (formData) => (dispatch) => {
   dispatch(setAddMealLoading(true));
 
   return mealImageUpload(formData.file, formData.dataurl, (error, url) => {
@@ -86,45 +83,45 @@ export const addMealItem = formData => dispatch => {
       const { file, dataurl, ...rest } = formData;
       const reqdata = { ...rest, image: url };
 
-      return (
-        axios.post(`/meal-items/`, reqdata)
-          .then((response) => {
-            const { mealItem } = response.data.payload;
-            toastSuccess('Meal successfully created');
-            dispatch(addMealItemSuccess(mealItem));
-            dispatch(showMealModalAction(false, false));
-            dispatch(setAddMealLoading(false));
-          })
-          .catch((err) => {
-            toastError("Meal name already exists, please try another.");
-            dispatch(addMealItemFailure(err));
-            dispatch(setAddMealLoading(false));
-          })
-      );
+      return axios
+        .post(`/meal-items/`, reqdata)
+        .then((response) => {
+          const { mealItem } = response.data.payload;
+          toastSuccess('Meal successfully created');
+          dispatch(addMealItemSuccess(mealItem));
+          dispatch(showMealModalAction(false, false));
+          dispatch(setAddMealLoading(false));
+        })
+        .catch((err) => {
+          toastError(err.response.data.msg);
+          dispatch(addMealItemFailure(err));
+          dispatch(setAddMealLoading(false));
+        });
     }
   });
 };
 
-export const deleteMealItemLoading = isDeleting => ({
+export const deleteMealItemLoading = (isDeleting) => ({
   type: DELETE_MEAL_ITEM_LOADING,
   payload: isDeleting,
 });
 
-export const deleteMealItemFailure = error => ({
+export const deleteMealItemFailure = (error) => ({
   type: DELETE_MEAL_ITEM_FAILURE,
-  payload: error
+  payload: error,
 });
 
-export const deleteMealItemSuccess = mealItemId => ({
+export const deleteMealItemSuccess = (mealItemId) => ({
   type: DELETE_MEAL_ITEM_SUCCESS,
   payload: mealItemId,
 });
 
-export const deleteMealItem = (mealItemId) => dispatch => {
+export const deleteMealItem = (mealItemId) => (dispatch) => {
   dispatch(deleteMealItemLoading(true));
-  return axios.delete(`/meal-items/${mealItemId}`)
+  return axios
+    .delete(`/meal-items/${mealItemId}`)
     .then(() => {
-      toastSuccess("Deleted successfully");
+      toastSuccess('Deleted successfully');
       dispatch(deleteMealItemSuccess(mealItemId));
       dispatch(deleteMealItemLoading(false));
     })
@@ -135,25 +132,25 @@ export const deleteMealItem = (mealItemId) => dispatch => {
     });
 };
 
-export const editMealItemLoading = isLoading => ({
+export const editMealItemLoading = (isLoading) => ({
   type: EDIT_MEAL_ITEM_LOADING,
-  payload: isLoading
+  payload: isLoading,
 });
 
-export const editMealItemFailure = error => ({
+export const editMealItemFailure = (error) => ({
   type: EDIT_MEAL_ITEM_FAILURE,
-  payload: error
+  payload: error,
 });
 
 export const editMealItemSuccess = (mealItemId, mealItem) => ({
   type: EDIT_MEAL_ITEM_SUCCESS,
   payload: {
     mealItemId,
-    mealItem
-  }
+    mealItem,
+  },
 });
 
-export const editMealItem = (mealItemId, formData) => dispatch => {
+export const editMealItem = (mealItemId, formData) => (dispatch) => {
   dispatch(editMealItemLoading(true));
   return mealImageUpload(formData.file, formData.dataurl, (error, url) => {
     if (error) {

--- a/client/src/components/Admin/Meals/MealModal/AddMealFields.jsx
+++ b/client/src/components/Admin/Meals/MealModal/AddMealFields.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 
 const AddMealFields = (props) => {
   const {
-    state: { name, desc, type },
+    state,
+    state: { name, type },
     errors,
     onChange,
-    mealTypes
+    mealTypes,
   } = props;
-
   return (
     <Fragment>
       <div className="two-col-wrap">
@@ -21,19 +21,14 @@ const AddMealFields = (props) => {
               <span
                 className="err-invalid"
                 style={{
-                  display: errors.includes('name')
-                    ? 'inline-block'
-                    : 'none'
+                  display: errors.includes('name') ? 'inline-block' : 'none',
                 }}
-              > * Invalid
+              >
+                {' '}
+                * Invalid
               </span>
             </label>
-            <input
-              type="text"
-              name="name"
-              value={name}
-              onChange={onChange}
-            />
+            <input type="text" name="name" value={name} onChange={onChange} />
           </div>
         </div>
 
@@ -44,51 +39,23 @@ const AddMealFields = (props) => {
               <span
                 className="err-invalid"
                 style={{
-                  display: errors.includes('type')
-                    ? 'inline-block'
-                    : 'none'
+                  display: errors.includes('type') ? 'inline-block' : 'none',
                 }}
-              > * Invalid
+              >
+                {' '}
+                * Invalid
               </span>
             </label>
-            <select
-              onChange={onChange}
-              name="type"
-              value={type}
-            >
+            <select onChange={onChange} name="type" value={type}>
               <option value="">-- select --</option>
-              { mealTypes.map(mealType => (
-                <option
-                  key={mealType}
-                  value={mealType.toLowerCase()}
-                >
+              {mealTypes.map((mealType) => (
+                <option key={mealType} value={mealType.toLowerCase()}>
                   {mealType}
                 </option>
               ))}
             </select>
           </div>
         </div>
-      </div>
-
-      <div className="form-field-set">
-        <label htmlFor="desc">
-          Description
-          <span
-            className="err-invalid"
-            style={{
-              display: errors.includes('desc')
-                ? 'inline-block'
-                : 'none'
-            }}
-          > * Invalid
-          </span>
-        </label>
-        <input
-          name="desc"
-          type="text"
-          value={desc}
-          onChange={onChange}
-        />
       </div>
     </Fragment>
   );
@@ -97,12 +64,11 @@ const AddMealFields = (props) => {
 AddMealFields.propTypes = {
   state: PropTypes.shape({
     name: PropTypes.string,
-    desc: PropTypes.string,
-    type: PropTypes.string
+    type: PropTypes.string,
   }),
   errors: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func,
-  mealTypes: PropTypes.arrayOf(PropTypes.string)
+  mealTypes: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default AddMealFields;

--- a/client/src/components/Admin/Meals/MealModal/Index.jsx
+++ b/client/src/components/Admin/Meals/MealModal/Index.jsx
@@ -6,11 +6,14 @@ import ImageView from './ImageView';
 import AddMealFields from './AddMealFields';
 
 import {
-  validateAddMealImage, generateFormData
+  validateAddMealImage,
+  generateFormData,
 } from '../../../../helpers/mealsHelper';
 
 import {
-  addMealItem, setAddMealErrors, editMealItem
+  addMealItem,
+  setAddMealErrors,
+  editMealItem,
 } from '../../../../actions/admin/mealItemsAction';
 
 import defaultImage from '../../../../assets/images/default.png';
@@ -27,26 +30,21 @@ class MealModal extends Component {
     image: {
       file: null,
       dataurl: defaultImage,
-      error: null
+      error: null,
     },
 
     name: '',
     type: '',
-    desc: '',
   };
 
   constructor(props) {
     super(props);
     this.imageInput = createRef();
-  
-    this.mealTypes = [
-      'Main',
-      'Side',
-      'Protein'
-    ];
+
+    this.mealTypes = ['Main', 'Side', 'Protein'];
 
     this.state = {
-      ...MealModal.initalState
+      ...MealModal.initalState,
     };
   }
 
@@ -61,9 +59,9 @@ class MealModal extends Component {
    *
    *
    * @description handle onChage event
-   * 
+   *
    * @param { Object } event
-   * 
+   *
    * @returns { undefined }
    */
   onChange = (event) => {
@@ -74,25 +72,22 @@ class MealModal extends Component {
     if (errors.length > 0) {
       this.props.setAddMealErrors([]);
     }
-  }
+  };
 
   /**
    *
    *
    * @description handle onSubmit event
-   * 
+   *
    * @param { Object } event
-   * 
+   *
    * @returns { undefined }
    */
   onSubmit = (event) => {
     const { edit, mealDetails } = this.props;
 
     event.preventDefault();
-    const formData = generateFormData(
-      this.state,
-      this.mealTypes
-    );
+    const formData = generateFormData(this.state, this.mealTypes);
 
     if (Array.isArray(formData)) {
       this.props.setAddMealErrors(formData);
@@ -100,21 +95,21 @@ class MealModal extends Component {
       if (edit) {
         const mealData = {
           ...formData,
-          mealName: (this.props.mealDetails.name === formData.mealName)
-            ? '' : formData.mealName
+          mealName:
+            this.props.mealDetails.name === formData.mealName
+              ? ''
+              : formData.mealName,
         };
 
         return this.props.editMealItem(mealDetails.id, mealData);
       }
       this.props.addMealItem(formData);
     }
-  }
+  };
 
   static getDerivedStateFromProps({ mealDetails, edit }, { type }) {
     if (edit && !type) {
-      const {
-        id, name, image, mealType, description
-      } = mealDetails;
+      const { id, name, image, mealType } = mealDetails;
 
       return {
         id,
@@ -122,10 +117,9 @@ class MealModal extends Component {
         image: {
           dataurl: image,
           file: null,
-          error: null
+          error: null,
         },
-        desc: description,
-        type: mealType
+        type: mealType,
       };
     }
 
@@ -136,25 +130,25 @@ class MealModal extends Component {
     this.props.setAddMealErrors([]);
 
     this.setState({
-      ...MealModal.initalState
+      ...MealModal.initalState,
     });
 
     if (this.imageInput.current) {
       this.imageInput.current.value = '';
     }
-  }
+  };
 
   closeModal = () => {
     this.clearModal();
     this.props.toggleAddModal(null, false);
-  }
+  };
 
   openFileDialog = () => {
     const { current: element } = this.imageInput;
     if (!element) return;
 
     element.click();
-  }
+  };
 
   previewImage = () => {
     const { current: element } = this.imageInput;
@@ -169,8 +163,8 @@ class MealModal extends Component {
           image: {
             file: image,
             dataurl: reader.result,
-            error: null
-          }
+            error: null,
+          },
         });
       };
       reader.readAsDataURL(image);
@@ -179,30 +173,27 @@ class MealModal extends Component {
         image: {
           file: null,
           dataurl: null,
-          error: status
-        }
+          error: status,
+        },
       });
     }
-  }
+  };
 
   render() {
+    const { show, edit, errors, isLoading, addBtnDisabled } = this.props;
+
     const {
-      show,
-      edit,
-      errors,
-      isLoading,
-      addBtnDisabled,
-    } = this.props;
-    
-    const {
-      name, type, desc, image: { dataurl }
+      name,
+      type,
+      image: { dataurl },
     } = this.state;
 
     let { error } = this.state.image;
 
-    error = (error === null && errors.includes('image'))
-      ? 'No image has been selected'
-      : error;
+    error =
+      error === null && errors.includes('image')
+        ? 'No image has been selected'
+        : error;
 
     return (
       <div
@@ -212,7 +203,9 @@ class MealModal extends Component {
       >
         <div className="modal-content">
           <div className="modal-header">
-            <div className="header-title">{edit ? 'EDIT' : 'ADD'} MEAL ITEM</div>
+            <div className="header-title">
+              {edit ? 'EDIT' : 'ADD'} MEAL ITEM
+            </div>
             <div>
               <button
                 tabIndex={0}
@@ -236,10 +229,7 @@ class MealModal extends Component {
             <main>
               <div>
                 Upload meal thumbnail. &nbsp;
-                <Link
-                  to="#"
-                  onClick={this.openFileDialog}
-                >
+                <Link to="#" onClick={this.openFileDialog}>
                   Select from computer
                 </Link>
               </div>
@@ -253,7 +243,6 @@ class MealModal extends Component {
               <AddMealFields
                 state={{
                   name,
-                  desc,
                   type,
                 }}
                 errors={errors}
@@ -277,10 +266,7 @@ class MealModal extends Component {
               >
                 Cancel
               </button>
-              <button
-                type="submit"
-                disabled={addBtnDisabled}
-              >
+              <button type="submit" disabled={addBtnDisabled}>
                 {edit ? 'Update' : 'Add'} meal item
               </button>
             </div>
@@ -301,7 +287,7 @@ MealModal.propTypes = {
   addBtnDisabled: PropTypes.bool,
   setAddMealErrors: PropTypes.func.isRequired,
   mealDetails: PropTypes.shape({
-    name: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired,
   }),
   editMealItem: PropTypes.func,
 };
@@ -313,8 +299,11 @@ const mapStateToProps = ({ mealItems: { mealModal } }) => ({
   edit: mealModal.edit,
 });
 
-export default connect(mapStateToProps, {
-  addMealItem,
-  setAddMealErrors,
-  editMealItem
-})(MealModal);
+export default connect(
+  mapStateToProps,
+  {
+    addMealItem,
+    setAddMealErrors,
+    editMealItem,
+  }
+)(MealModal);

--- a/client/src/helpers/mealsHelper.js
+++ b/client/src/helpers/mealsHelper.js
@@ -10,24 +10,18 @@ export const canOrderMeal = (day) => {
 
   if (dueTime < timeLeft && timeLeft < 184) {
     return true;
-  } 
+  }
   return false;
 };
 
 const today = new Date();
 today.setHours(0, 0, 0, 0);
 
-export const validateDate = (menu, endDate) => (
-  new Date(menu.date) <= endDate
-  && new Date(menu.date) >= today
-);
+export const validateDate = (menu, endDate) =>
+  new Date(menu.date) <= endDate && new Date(menu.date) >= today;
 
 export const validateAddMealImage = (image) => {
-  const exts = [
-    'image/jpg',
-    'image/jpeg',
-    'image/png'
-  ];
+  const exts = ['image/jpg', 'image/jpeg', 'image/png'];
 
   if (!(image instanceof File) || !exts.includes(image.type)) {
     return 'Image should be in JPEG or PNG format';
@@ -41,7 +35,9 @@ const validateInputFields = (mealDetails) => {
 
   Object.entries(mealDetails).forEach(([key, value]) => {
     if (key === 'image' || key === 'type') return [];
-    if (!value.toString().trim().length) { errors.push(key); }
+    if (!value.toString().trim().length) {
+      errors.push(key);
+    }
   });
 
   return errors;
@@ -49,41 +45,40 @@ const validateInputFields = (mealDetails) => {
 
 export const generateFormData = (mealDetails, types) => {
   const {
-    name, desc, type, image: { file, dataurl }
+    name,
+    type,
+    image: { file, dataurl },
   } = mealDetails;
-  
+
   const errors = [
     ...validateInputFields(mealDetails),
     ...(!dataurl ? ['image'] : []),
-    ...(!lowerCaseArray(types).includes(type) ? ['type'] : [])
+    ...(!lowerCaseArray(types).includes(type) ? ['type'] : []),
   ];
 
-  return errors.length ? errors
+  return errors.length
+    ? errors
     : {
-      mealName: title(name),
-      mealType: type.toLowerCase(),
-      description: title(desc),
-      file,
-      dataurl
-    };
+        mealName: title(name),
+        mealType: type.toLowerCase(),
+        file,
+        dataurl,
+      };
 };
 
-export const endDate = () => new Date(today.getFullYear(), 
-  today.getMonth(), today.getDate() + 10);
+export const endDate = () =>
+  new Date(today.getFullYear(), today.getMonth(), today.getDate() + 10);
 
-export const findUpdatedIndex = (prevState, updatedId) => (
-  prevState.findIndex(item => item.id === updatedId)
-);
+export const findUpdatedIndex = (prevState, updatedId) =>
+  prevState.findIndex((item) => item.id === updatedId);
 
-export const setMealImage = (image) => (
-  !image ? defMealImage : image
-);
+export const setMealImage = (image) => (!image ? defMealImage : image);
 
 export const mealImageUpload = (file, dataurl, callback) => {
   if (file instanceof File) {
     return upload(dataurl)
-      .then(payload => callback(null, payload.secure_url))
-      .catch(error => callback(error, null));
+      .then((payload) => callback(null, payload.secure_url))
+      .catch((error) => callback(error, null));
   }
 
   return callback(null, dataurl);

--- a/client/src/tests/components/Admin/Meals/MealModal.test.js
+++ b/client/src/tests/components/Admin/Meals/MealModal.test.js
@@ -51,7 +51,6 @@ describe('MealModal Component', () => {
 
   const mealObject = {
     name: 'Ugeli',
-    desc: 'Nice Meal',
     type: 'Side',
     image: {
       file: imageFile,
@@ -68,7 +67,6 @@ describe('MealModal Component', () => {
 
   it('should call the onChange method', () => {
     const name = 'Ugeli';
-    const desc = 'Meal Description';
 
     const event = {
       target: {
@@ -79,11 +77,6 @@ describe('MealModal Component', () => {
 
     wrapper.find('[name="name"]').simulate('change', event);
     expect(mealModal.state.name).toBe(name);
-
-    event.target.name = 'desc';
-    event.target.value = desc;
-    wrapper.find('[name="desc"]').simulate('change', event);
-    expect(mealModal.state.desc).toBe(desc);
   });
 
   it('call previewImage with invalid image', () => {
@@ -148,7 +141,6 @@ describe('MealModal Component', () => {
     mealModal.closeModal();
     expect(mealModal.state.name).toBe('');
     expect(mealModal.state.type).toBe('');
-    expect(mealModal.state.desc).toBe('');
   });
 
   it('should derive state from props if edit is true', () => {

--- a/client/src/tests/components/Admin/Meals/MealSessionModal/AddMealSessionFields.test.js
+++ b/client/src/tests/components/Admin/Meals/MealSessionModal/AddMealSessionFields.test.js
@@ -60,13 +60,6 @@ describe('MealModal Component', () => {
     expect(wrapper.length).toEqual(1);
   });
   it('should not call the fn onChange on the AddMealSessionFields props immediately', () => {
-    console.log(
-      'WRAPPER__:',
-      wrapper
-        .find('DatePicker')
-        .at(0)
-        .debug()
-    );
     const spy = jest.spyOn(
       wrapper.children().instance().props.children.props,
       'onChange'

--- a/client/src/tests/components/Admin/Meals/MealSessionModal/MealSessionModal.test.jsx
+++ b/client/src/tests/components/Admin/Meals/MealSessionModal/MealSessionModal.test.jsx
@@ -51,18 +51,6 @@ const setup = (edit) => {
 
 let wrapper = setup(false);
 
-// const testing = wrapper
-//   .children()
-//   .children()
-//   .children()
-//   .children()
-//   .children()
-//   .children()
-//   .find('form')
-//   .children();
-
-// console.log('TESTING__T__:', testing.get(0).find(''));
-
 describe('MealModal Component', () => {
   const mealSessionObject = {
     name: 'Lunch',

--- a/client/src/tests/helpers/mealsHelper.test.js
+++ b/client/src/tests/helpers/mealsHelper.test.js
@@ -3,8 +3,8 @@ import {
   endDate,
   canOrderMeal,
   generateFormData,
-  findUpdatedIndex
-} from "../../helpers/mealsHelper";
+  findUpdatedIndex,
+} from '../../helpers/mealsHelper';
 
 /* 
 global jest 
@@ -15,11 +15,10 @@ const today = new Date();
 const mealDetails = {
   name: 'Ugeli',
   type: 'side',
-  image: { 
+  image: {
     file: new File([''], 'filename.jpg', { type: 'image/jpg' }),
-    dataurl: 'data://path/to/image'
+    dataurl: 'data://path/to/image',
   },
-  desc: 'Description for meals'
 };
 
 const types = ['Side', 'Main', 'Soup', 'Protein'];
@@ -32,8 +31,7 @@ test('canOrderMeal method', () => {
   expect(canOrderMeal(menu.date)).toBe(false);
 
   const newDate = {
-    date: new Date(today.getFullYear(),
-      today.getMonth(), today.getDate() + 4)
+    date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 4),
   };
   const timLeft = (newDate - today) / 3600 / 1000;
   expect(canOrderMeal(newDate)).toBe(true);
@@ -44,7 +42,6 @@ test('returns an object of meal details', () => {
   const result = generateFormData(newMealDetails, types);
   expect(result.mealName).toBe(mealDetails.name);
   expect(result.mealType).toBe(mealDetails.type.toLowerCase());
-  expect(result.description).toBe(mealDetails.desc);
 });
 
 test('returns array of image string error', () => {


### PR DESCRIPTION
#### What does this PR do?
- It removes the `Description` field from the meal modal, ie, adding and editing.
#### Description of Task to be completed?
- Remove the `description` input box in the `add new meal` modal
#### How should this be manually tested?
- Clone the repo and checkout the `ft-input-description-166010381` branch.
- Run the application, as an admin, and navigate to the `/admin/meals` uri.
- Add a new meal, or try editing an existing one.
- You should see the `Name` and `Meal type` fields and no longer the `Description`.

#### What are the relevant pivotal tracker stories?
- [#166010381](https://www.pivotaltracker.com/story/show/166010381)

#### Screenshots (If Applicable)
<img width="1201" alt="Screen Shot 2019-05-22 at 10 48 05" src="https://user-images.githubusercontent.com/30738053/58156598-1fefa280-7c7f-11e9-9f81-cc90af4e0bce.png">

