### PR TITLE
 #166032722  Fix view Menus error

### DIFF
--- a/client/src/components/Admin/Menus/Index.jsx
+++ b/client/src/components/Admin/Menus/Index.jsx
@@ -57,7 +57,7 @@ export class Menus extends Component {
   /**
    * @description update menus
    * Can be removed in favor of loading menus from DB
-   * 
+   *
    * @memberof Menus
    *
    * @returns { undefined }
@@ -65,17 +65,17 @@ export class Menus extends Component {
   componentDidMount() {
     this.props.fetchUpcomingEngagements();
     this.props.fetchMealItems();
-    this.props.fetchVendorEngagements();
     this.props.fetchMenus(formatDate(
-      this.state.startDate), formatDate(this.state.endDate)
-    );
+      this.state.startDate), formatDate(this.state.endDate)).then(() => {
+      this.props.fetchVendorEngagements();
+    });
   }
 
   /**
    * @description fetch menu given date range
    *
    * @memberof Menus
-   * 
+   *
    * @returns { undefined }
    */
   handleViewMenu = () => {
@@ -90,9 +90,9 @@ export class Menus extends Component {
 
   /**
    * @description handles date range change
-   * 
+   *
    * @memberof Menus
-   * 
+   *
    * @param { Object } selectOption
    * @param { Object } name
    * @returns { undefined }
@@ -104,9 +104,9 @@ export class Menus extends Component {
   }
 
   /**
-   * 
+   *
    * @method showAddModal
-   * 
+   *
    * @memberof Menus
    *
    * @param {Object} menu
@@ -127,9 +127,9 @@ export class Menus extends Component {
   /**
    *
    * @method showDeleteModal
-   * 
+   *
    * @memberof Menus
-   * 
+   *
    * @param {object} menuDetails
    *
    * @returns {void}
@@ -142,13 +142,13 @@ export class Menus extends Component {
   }
 
   /**
-   * 
+   *
    * @method deleteMenu
    *
    * @param {number} menuId
-   * 
+   *
    * @memberof Menu
-   * 
+   *
    * @returns {void}
    */
   deleteMenu = (menuId) => {
@@ -157,13 +157,13 @@ export class Menus extends Component {
   }
 
   /**
-   * 
+   *
    * @method closeModal
    *
    * @param {object} vendor
-   * 
+   *
    * @memberof Menu
-   * 
+   *
    * @returns {void}
    */
   closeModal = () => {
@@ -172,11 +172,11 @@ export class Menus extends Component {
 
   /**
    * Handles form submission
-   * 
+   *
    * @param {object} menu
    *
    * @memberof Menu
-   * 
+   *
    * @returns {void}
    */
   handleSubmit = (menu) => {
@@ -200,7 +200,7 @@ export class Menus extends Component {
    * @description render menus section
    *
    * @memberof Menus
-   * 
+   *
    * @returns { JSX }
    */
   renderMenus = () => {
@@ -208,7 +208,7 @@ export class Menus extends Component {
       error,
       menuList,
       isDeleting,
- 
+
       mealItems,
       isCreating
     } = this.props.menus;

--- a/client/src/tests/components/Admin/Meals/MealSessionModal/AddMealSessionFields.test.js
+++ b/client/src/tests/components/Admin/Meals/MealSessionModal/AddMealSessionFields.test.js
@@ -60,13 +60,6 @@ describe('MealModal Component', () => {
     expect(wrapper.length).toEqual(1);
   });
   it('should not call the fn onChange on the AddMealSessionFields props immediately', () => {
-    console.log(
-      'WRAPPER__:',
-      wrapper
-        .find('DatePicker')
-        .at(0)
-        .debug()
-    );
     const spy = jest.spyOn(
       wrapper.children().instance().props.children.props,
       'onChange'

--- a/client/src/tests/components/Admin/Menus/Index.test.js
+++ b/client/src/tests/components/Admin/Menus/Index.test.js
@@ -2,12 +2,16 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Menus, mapStateToProps } from '../../../../components/Admin/Menus/Index';
+import moment from 'moment';
+import DatePicker from 'react-datepicker';
+import {
+  Menus,
+  mapStateToProps
+} from '../../../../components/Admin/Menus/Index';
 import menu from '../../../__mocks__/mockMenuList';
 import engagement from '../../../__mocks__/mockEngagements';
 import Loader from '../../../../components/common/Loader/Loader';
-import moment from 'moment';
-import DatePicker from 'react-datepicker';
+
 
 const menusState = {
   error: {
@@ -32,7 +36,7 @@ describe('Admin: Menu Component', () => {
 
   const props = {
     menus: { ...menusState },
-    fetchMenus: jest.fn(),
+    fetchMenus: jest.fn(() => Promise.resolve()),
     fetchVendorEngagements: jest.fn(),
     fetchMealItems: jest.fn(),
     createMenu: jest.fn(() => Promise.resolve()),
@@ -45,7 +49,7 @@ describe('Admin: Menu Component', () => {
 
   beforeEach(() => {
     wrapper = shallow(
-      <Menus {...props} />)
+      <Menus {...props} />);
   });
 
   afterEach(() => {
@@ -81,7 +85,7 @@ describe('Admin: Menu Component', () => {
 
   it('should call showAddModal method when editing a menu', () => {
     expect(wrapper.instance().state.displayModal).toBeFalsy();
-    wrapper.find('#add-menu').simulate('click'); 
+    wrapper.find('#add-menu').simulate('click');
     expect(wrapper.instance().state.displayModal).toBeTruthy();
   });
 
@@ -117,9 +121,9 @@ describe('Admin: Menu Component', () => {
   });
 
   it('should call deleteMenu on clicking delete', () => {
-    const spy = jest.spyOn(wrapper.instance(), 'showDeleteModal')
+    const spy = jest.spyOn(wrapper.instance(), 'showDeleteModal');
     wrapper.instance().showDeleteModal({});
-    expect(spy).toHaveBeenCalled()
+    expect(spy).toHaveBeenCalled();
   });
 
   it('should show error if endDate is greater than startDate', () => {
@@ -128,12 +132,12 @@ describe('Admin: Menu Component', () => {
       startDate: moment().add(1, 'days'),
     });
     wrapper.find('#view-menu').simulate('click');
-    expect(wrapper.find('.Toastify__toast--error')).toBeTruthy()
-  })
+    expect(wrapper.find('.Toastify__toast--error')).toBeTruthy();
+  });
 
   it('changes date', () => {
     wrapper.find(DatePicker).at(0).simulate('change', '2019-02-03');
-    expect(wrapper.instance().state.startDate).toEqual('2019-02-03')
+    expect(wrapper.instance().state.startDate).toEqual('2019-02-03');
     wrapper.find(DatePicker).at(1).simulate('change');
   });
 
@@ -146,10 +150,10 @@ describe('Admin: Menu Component', () => {
     it('mapStateToProps', () => {
       const initialState = {
         menus: menu,
-        allEngagements: {upComingEngagements: {engagements: engagement}}
-      }
+        allEngagements: { upComingEngagements: { engagements: engagement } }
+      };
 
-      expect(mapStateToProps(initialState).menus).toEqual(menu)
+      expect(mapStateToProps(initialState).menus).toEqual(menu);
     });
-  })
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- Fixes the error that is returned when a user clicks on menus.

#### Description of Task to be completed?
- modify Menus component
- modify Menus test

#### How should this be manually tested?
- Run`git fetch` and `git checkout fix-view-menus-166032722`
- Log in to the app
- Navigate to admin
- Click on the `Manage Menus` and then `Menus`. You will be able to view available menus for that day.

#### What are the relevant pivotal tracker stories?
- [#166032722](https://www.pivotaltracker.com/story/show/166032722)

#### Background Context
Currently when a user clicks on the `Menus` under `Manage Menus` `Error occurred while loading menus :-( ` is returned even when there are menus to show

#### Screenshots (If Applicable)
***Before Fix***
![May-22-2019 12-41-01 menu2](https://user-images.githubusercontent.com/9887151/58242115-ea1ded00-7d56-11e9-8930-6b005e6187a5.gif)
***After Fix***
![May-22-2019 12-35-26 menu1](https://user-images.githubusercontent.com/9887151/58242217-0e79c980-7d57-11e9-8311-dd72409967cb.gif)

