### PR TITLE
#166698914 Fix - `AssignAdmin role` page does not update real-time

### DIFF
--- a/client/src/components/Admin/Users/AdminUsers.jsx
+++ b/client/src/components/Admin/Users/AdminUsers.jsx
@@ -21,6 +21,10 @@ import EmptyContent from "../../common/EmptyContent";
  * @extends {Component}
  */
 export class Users extends Component {
+  state = {
+    emailAddress: '',
+  };
+
   componentDidMount() {
     this.props.getAllAdminUsers();
   }
@@ -33,22 +37,40 @@ export class Users extends Component {
    * @memberOf Users
    */
   handleSubmit = (event) => {
-    event.preventDefault();
     const userData = {
-      emailAddress: event.target.elements.userEmail.value,
+      emailAddress: this.state,
       roleId: 1
     };
-    this.props.createAdminUser(userData);
+    this.props.createAdminUser(userData).then(() => { this.setState({ emailAddress: '', }); });
   }
+
+  /**
+   *
+   * @param {event} event
+   *
+   * @returns {void}
+   * @memberOf Users
+   */
+  onChange = (event) => {
+    const { name, value } = event.target;
+    this.setState({ [name]: value });
+  };
 
   render() {
     const { adminUsers, loading } = this.props;
+    const { emailAddress } = this.state;
     return (
       <div>
         <span className="heading-style">Assign Admin role to a user</span>
         <form className="parent-div" onSubmit={this.handleSubmit}>
           <label htmlFor="userEmail">Email</label>
-          <input className="user-form" type="text" id="userEmail" name="userEmail" />
+          <input
+            id="userEmail"
+            className="user-form"
+            name="emailAddress"
+            onChange={this.onChange}
+            value={emailAddress}
+          />
           <button type="submit" className="assign-role button-right">
             Assign Admin Role
           </button>

--- a/client/src/reducers/admin/adminUserReducer.js
+++ b/client/src/reducers/admin/adminUserReducer.js
@@ -31,7 +31,8 @@ const adminUserReducer = (state = initialUser, action) => {
     case ADD_ADMIN_USER_SUCCESS:
       return {
         ...state,
-        message: action.message
+        message: action.message,
+        adminUsers: [...state.adminUsers, action.payload],
       };
     case ADD_ADMIN_USER_FAILURE:
       return {

--- a/client/src/tests/components/Admin/Users/AdminUsers.test.js
+++ b/client/src/tests/components/Admin/Users/AdminUsers.test.js
@@ -8,7 +8,7 @@ const props = {
   adminUsers: [{ name: 'miriam', email: "mim@gmail.com" }],
   message: "",
   userEmail: "",
-  createAdminUser: jest.fn(),
+  createAdminUser: jest.fn().mockImplementation(() => Promise.resolve()),
   getAllAdminUsers: jest.fn(),
   loading: false
 };
@@ -41,7 +41,6 @@ describe('Users Component', () => {
           },
         }
       },
-      preventDefault: jest.fn(),
     };
 
     wrapper.update();
@@ -51,6 +50,12 @@ describe('Users Component', () => {
 
     expect(props.createAdminUser).toBeCalled();
   });
+
+  it('should change email address', () => {
+    wrapper.instance().onChange({ target: { name: 'emailAdress', value: 'welike.amos@gmail.com' } });
+    expect(wrapper.instance().state.emailAdress).toEqual('welike.amos@gmail.com');
+  });
+
   describe('mapStateToProps', () => {
     it('should map Users to state', () => {
       const initialState = {


### PR DESCRIPTION
<!---[Fixes #166698914] -->

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

#### What does this PR do?
- Fixes - `AssignAdmin role` page which does not update in real-time
- Clears the text box after the submission of the email is done

#### Description of Task to be completed?
- increase end date for fetching menus
#### How should this be manually tested?
- Log into the application.
- Place an order for a day a week from now , you should be able to edit the order without an errors.

#### What are the relevant pivotal tracker stories?
- [#166698914](https://www.pivotaltracker.com/story/show/166698914)

#### Background Context
- There is a need to improve UX when one assigns the admin role to a user. Currently, the AssignAdmin role page does not update real-time when the admin role has been assigned successfully to a new user. And Also the text in the input box is cleared.
#### Screenshots (If Applicable)
N/A