### PR TITLE
#166698914 Fix - AssignAdmin role page does not update real-time

### DIFF
--- a/client/src/actions/admin/adminUserAction.js
+++ b/client/src/actions/admin/adminUserAction.js
@@ -90,9 +90,9 @@ const isFetchingRoles = (payload) => ({
   payload
 });
 
-export const addAdminUser = (message, type) => ({
+export const addAdminUser = (type, payload) => ({
   type,
-  message
+  payload
 });
 
 export const deleteUserLoading = () => ({
@@ -217,17 +217,19 @@ export const getAllPermisions = (adminId) => dispatch => {
     });
 };
 
-export const createAdminUser = (userData) => dispatch => axios.post(`/roles/user`, userData)
-  .then((response) => {
-    const { msg } = response.data;
-    toastSuccess("User role changed to Admin successfully");
-    dispatch(addAdminUser(msg, ADD_ADMIN_USER_SUCCESS));
-  })
-  .catch((error) => {
-    error = error.response.data.msg;
-    toastError(error);
-    dispatch(addAdminUser(error, ADD_ADMIN_USER_FAILURE));
-  });
+export const createAdminUser = (userData) => dispatch => {
+  return axios.post(`/roles/user`, userData)
+    .then((response) => {
+      const payload = response.data.payload.user_role;
+      toastSuccess("User role changed to Admin successfully");
+      dispatch(addAdminUser(ADD_ADMIN_USER_SUCCESS, payload));
+    })
+    .catch((error) => {
+      error = error.response.data.msg;
+      toastError(error);
+      dispatch(addAdminUser(ADD_ADMIN_USER_FAILURE, error));
+    });
+};
 
 export const addUserRole = (type, role) => ({
   type,

--- a/client/src/components/Admin/Users/AdminUsers.jsx
+++ b/client/src/components/Admin/Users/AdminUsers.jsx
@@ -21,6 +21,10 @@ import EmptyContent from "../../common/EmptyContent";
  * @extends {Component}
  */
 export class Users extends Component {
+  state = {
+    emailAddress: '',
+  };
+
   componentDidMount() {
     this.props.getAllAdminUsers();
   }
@@ -34,21 +38,43 @@ export class Users extends Component {
    */
   handleSubmit = (event) => {
     event.preventDefault();
+    const { emailAddress } = this.state;
+    const emailData = emailAddress.trim();
     const userData = {
-      emailAddress: event.target.elements.userEmail.value,
+      emailAddress: emailData,
       roleId: 1
     };
-    this.props.createAdminUser(userData);
+    this.props.createAdminUser(userData)
+      .then(() => { this.setState({ emailAddress: '', }); });
   }
+
+  /**
+   *
+   * @param {e} e
+   *
+   * @returns {void}
+   * @memberOf Users
+   */
+  onChange = (e) => {
+    const { value } = e.target;
+    this.setState({ emailAddress: value });
+  };
 
   render() {
     const { adminUsers, loading } = this.props;
+    const { emailAddress } = this.state;
     return (
       <div>
         <span className="heading-style">Assign Admin role to a user</span>
         <form className="parent-div" onSubmit={this.handleSubmit}>
           <label htmlFor="userEmail">Email</label>
-          <input className="user-form" type="text" id="userEmail" name="userEmail" />
+          <input
+            id="userEmail"
+            className="user-form"
+            name="emailAddress"
+            onChange={this.onChange}
+            value={emailAddress}
+          />
           <button type="submit" className="assign-role button-right">
             Assign Admin Role
           </button>
@@ -95,7 +121,6 @@ export class Users extends Component {
 
 export const mapStateToProps = state => ({
   userEmail: state.user.email,
-  message: state.user.message,
   adminUsers: state.user.adminUsers,
   loading: state.user.isloading
 });

--- a/client/src/reducers/admin/adminUserReducer.js
+++ b/client/src/reducers/admin/adminUserReducer.js
@@ -31,7 +31,7 @@ const adminUserReducer = (state = initialUser, action) => {
     case ADD_ADMIN_USER_SUCCESS:
       return {
         ...state,
-        message: action.message
+        adminUsers: [action.payload, ...state.adminUsers],
       };
     case ADD_ADMIN_USER_FAILURE:
       return {

--- a/client/src/tests/__mocks__/mockAdminUsers.js
+++ b/client/src/tests/__mocks__/mockAdminUsers.js
@@ -14,7 +14,25 @@ export const adminUsers = {
         ]
       }
     ]
+  },
+};
+
+export const newAdminUser = { 
+  // data: {
+  msg: "OK",
+  payload: {
+    user_role: {
+      email: "admin.user@andela.com",
+      id: 76,
+      isActive: true,
+      isDeleted: false,
+      locationId: 1,
+      roleId: 1,
+      timestamps: { created_at: "2019-06-17", updated_at: "Mon, 17 Jun 2019 11:00:55 GMT" } 
+    },
+    userId: "-LTY8T0N1_9gwLINyKuY" 
   }
+  // },
 };
 
 export const roles = {
@@ -125,6 +143,6 @@ export const tappedUsers = {
       { date: "2019-06-11", count: 0 }
     ]
   }
-}
+};
 
 export const roleId = 1;

--- a/client/src/tests/actions/admin/adminUserAction.test.js
+++ b/client/src/tests/actions/admin/adminUserAction.test.js
@@ -52,7 +52,7 @@ import {
   updateUser
 } from '../../../actions/admin/adminUserAction';
 import {
-  adminUsers, roles, permisions, roleId, RolePermisions, permisionData, tappedUsers
+  adminUsers, roles, permisions, roleId, RolePermisions, permisionData, tappedUsers, newAdminUser
 } from '../../__mocks__/mockAdminUsers';
 
 export const users = [
@@ -165,16 +165,14 @@ describe('Get User Role Action', () => {
     it('should successfully create an admin user', async (done) => {
       moxios.stubRequest(`/roles/user`, {
         status: 201,
-        response: {
-          msg: adminUsers.msg
-        }
+        response: newAdminUser
       });
 
       const expectedActions = [
 
         {
           type: ADD_ADMIN_USER_SUCCESS,
-          message: adminUsers.msg
+          payload: newAdminUser.payload.user_role
         },
 
       ];

--- a/client/src/tests/components/Admin/Users/AdminUsers.test.js
+++ b/client/src/tests/components/Admin/Users/AdminUsers.test.js
@@ -8,12 +8,16 @@ const props = {
   adminUsers: [{ name: 'miriam', email: "mim@gmail.com" }],
   message: "",
   userEmail: "",
-  createAdminUser: jest.fn(),
+  createAdminUser: jest.fn().mockImplementation(() => Promise.resolve()),
   getAllAdminUsers: jest.fn(),
-  loading: false
+  loading: false,
 };
 
 const wrapper = shallow(<Users {...props} />);
+
+const state = {
+  emailAddress: '',
+};
 
 describe('Users Component', () => {
   it('should render correctly', () => {
@@ -51,6 +55,12 @@ describe('Users Component', () => {
 
     expect(props.createAdminUser).toBeCalled();
   });
+
+  it('should change email address', () => {
+    wrapper.instance().onChange({ target: { name: 'emailAdress', value: 'welike.amos@gmail.com' } });
+    expect(wrapper.instance().state.emailAddress).toEqual('welike.amos@gmail.com');
+  });
+
   describe('mapStateToProps', () => {
     it('should map Users to state', () => {
       const initialState = {

--- a/client/src/tests/reducers/admin/adminUserReducer.test.js
+++ b/client/src/tests/reducers/admin/adminUserReducer.test.js
@@ -44,7 +44,7 @@ describe('Admin User Reducer', () => {
   it('should update message', () => {
     const action = {
       type: ADD_ADMIN_USER_SUCCESS,
-      message: "successfully done"
+      message: ""
     };
     const newState = adminUserReducer(initialUser, action);
     expect(newState.message).toEqual(action.message);


### PR DESCRIPTION
<!---[Fixes #166698914] -->

<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

#### What does this PR do?
- Fixes - `AssignAdmin role` page which does not update in real-time
- Clears the text box after the submission of the email is done

#### Description of Task to be completed?
- Currently, the AssignAdmin role page does not update real-time when the admin role has been assigned successfully to a new user. And Also the text in the input box is cleared.

#### How should this be manually tested?
- Log into the application.
- Access the Admin Panel, navigate to the Users panel and assign a new admin role.

#### What are the relevant pivotal tracker stories?
- [#166698914](https://www.pivotaltracker.com/story/show/166698914)

#### Background Context
- There is a need to improve UX when one assigns the admin role to a user. Currently, the AssignAdmin role page does not update real-time when the admin role has been assigned successfully to a new user. And Also the text in the input box is cleared.
#### Screenshots (If Applicable)
N/A