### PR TITLE
#166756873 Increase sidenav width 

### DIFF
--- a/client/src/styles/_globals.scss
+++ b/client/src/styles/_globals.scss
@@ -13,7 +13,8 @@ body,
 .wrapper
 .main-container
 .section {
-  padding: 40px 0;
+ padding: 40px 0;
+ margin-left: 7%;
 }
 
 body {

--- a/client/src/styles/components/_sidenav.scss
+++ b/client/src/styles/components/_sidenav.scss
@@ -1,10 +1,9 @@
 .side-nav {
   height: 100%;
-  width: 150px;
+  width: 13%;
   background-color: #f4f8f9;
   box-shadow: inset -1px 0 0 0 #dcdcdc;
   position: fixed;
-  overflow: scroll;
 }
 .side-nav-item-wrapper {
   width: 99.5%;
@@ -58,13 +57,11 @@
   width: 100%;
   position: relative;
   cursor: pointer;
-  justify-content: center;
-  align-items: center;
+  text-align: center;
   padding-top: 10px;
-  padding-left: 30px;
   color: $color-medium-gray;
   font-weight: 600;
-  font-size: 12px;
+  font-size: 11px;
 
   &.active {
     background-color: $color-green-light;


### PR DESCRIPTION
#### What does this PR do?

- Increases the Sidenav width to avoid overlapping of the side nav items when the zoom is less than 50%

#### Description of Task to be completed?
- modify sidenav.scss 
- modify _globals.scss

#### How should this be manually tested?
- Check out to this branch.
- Log into the application.
- Set your screen zoom below 50%, the side nav items will not be overlapping.

#### What are the relevant pivotal tracker stories?

- [#166756873](https://www.pivotaltracker.com/story/show/166756873)

#### Background Context
- Currently, when the screen zoom is less than 50% the side nav items overlap.

