### PR TITLE
#166791519 display available menus in increasing date order

### DIFF
--- a/client/src/components/Order/Orders.jsx
+++ b/client/src/components/Order/Orders.jsx
@@ -153,12 +153,13 @@ export class Orders extends Component {
       createOrder //eslint-disable-line
     } = this.props;
 
+    const { selectedMenu, menuListId } = this.state;
+
     const menuList = menus.reduce((accu, curr) => {
       return [...accu, ...curr.menus]
     }, []);
+    menuList.reverse();
 
-    const { selectedMenu, menuListId } = this.state;
-    
     return (
       <div>
         {isLoading ? (


### PR DESCRIPTION
#### What does this PR do?
- Displays  available menus in increasing order of the date

#### Description of Task to be completed?

- Reverse the list of menus

#### How should this be manually tested?

   - Run `git fetch` and checkout to this branch
   - Log in to the app
   - Click home on the menu bar
   - Available menus will be displayed in  increasing order of date

#### What are the relevant pivotal tracker stories?
- [#166791519](https://www.pivotaltracker.com/story/show/166791519)

#### Background Context
- Currently, the available menus are displayed in a decreasing order of date.
