### PR TITLE
#166791660 fix sideMeal and protein selection

### DIFF
--- a/client/src/components/Admin/Menus/MenuModal.jsx
+++ b/client/src/components/Admin/Menus/MenuModal.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { Component, Fragment } from 'react';
-import { 
+import {
   func, shape, string, array, bool, date, object
 } from 'prop-types';
 import Select from 'react-select';
@@ -13,7 +13,7 @@ import formatMealItems, { getIds, formatDate } from '../../../helpers/formatMeal
 import { adminAllowed } from '../../../tests/__mocks__/mockMenuItems';
 
 /**
- * 
+ *
  * @class MenuModal
  * @extends Component
  */
@@ -68,10 +68,10 @@ class MenuModal extends Component {
    * @method onChange
    *
    * @memberOf MenuModal
-   * 
+   *
    * @param {object} selectOption
    * @param {object} name
-   * 
+   *
    * @returns {void}
    */
   onChange = (selectOption, name) => {
@@ -86,11 +86,11 @@ class MenuModal extends Component {
   };
 
   /**
-   * 
+   *
    * @method checkAllowedSelection
-   * 
+   *
    * @memberOf MenuModal
-   * 
+   *
    * @returns {void}
    */
   checkAllowedSelection = () => {
@@ -102,14 +102,34 @@ class MenuModal extends Component {
       allowedProtein,
       mainItem,
       collectionDate,
-      vendorEngagementId 
+      vendorEngagementId
     } = this.state;
+
+    if (sideMeal.length < allowedSideMeal.value) {
+      this.setState({
+        errors: {
+          sideMeal: 'Side meals should not be less than Allowed Side Meal'
+        }
+      });
+
+      return;
+    }
+
+    if (protein.length < allowedProtein.value) {
+      this.setState({
+        errors: {
+          protein: 'Proteins not be less than Allowed Protein'
+        }
+      });
+
+      return;
+    }
 
     if (Object.keys(check).length !== 0) {
       this.setState({ errors: check });
     } else {
       this.props.handleSubmit({
-        date: formatDate(collectionDate), 
+        date: formatDate(collectionDate),
         mealPeriod: "Lunch",
         mainMealId: mainItem.value,
         allowedSide: allowedSideMeal.value,
@@ -122,13 +142,13 @@ class MenuModal extends Component {
   }
 
   /**
-   * 
+   *
    * @method formValidation
-   * 
+   *
    * @memberOf MenuModal
-   * 
+   *
    * @param {object} event
-   * 
+   *
    * @returns {void}
    */
   formValidation = (event) => {
@@ -142,11 +162,11 @@ class MenuModal extends Component {
   };
 
   /**
-   * 
+   *
    * @method handleCloseModal
-   * 
+   *
    * @memberOf MenuModal
-   * 
+   *
    * @returns Void
    */
   handleCloseModal = () => {
@@ -178,9 +198,9 @@ class MenuModal extends Component {
     const formatedMealItems = formatMealItems(mealItems);
     return (
       <Fragment>
-        <div 
+        <div
           className="modal"
-          id="menu-modal" 
+          id="menu-modal"
           style={displayModal ? { display: 'block' } : { display: 'none' }}
         >
           <div className="modal-content">
@@ -224,7 +244,7 @@ class MenuModal extends Component {
                     </label>
                     <Select
                       onChange={(e) => this.onChange(e, 'mainItem')}
-                      name="mainItem" 
+                      name="mainItem"
                       id="mainItem"
                       value={mainItem}
                       options={formatedMealItems.main}
@@ -269,7 +289,7 @@ class MenuModal extends Component {
                     </label>
                     <Select
                       onChange={(e) => this.onChange(e, "allowedProtein")}
-                      name="allowedProtein" 
+                      name="allowedProtein"
                       value={allowedProtein}
                       options={adminAllowed}
                       isClearable
@@ -279,11 +299,11 @@ class MenuModal extends Component {
                 </div>
                 <div className="form-field-single">
                   <label htmlFor="soup">Side meal&nbsp;
-                    <span>
+                    <span className="errors">
                       {errors.sideMeal ? errors.sideMeal : ""}
                     </span>
                   </label>
-                  <Select 
+                  <Select
                     onChange={(e) => this.onChange(e, 'sideMeal')}
                     isMulti
                     value={sideMeal}
@@ -293,7 +313,7 @@ class MenuModal extends Component {
                 </div>
                 <div className="form-field-single">
                   <label htmlFor="Protien">Protein&nbsp;
-                    <span>
+                    <span className="errors">
                       {errors.protein ? errors.protein : ""}
                     </span>
                   </label>
@@ -313,7 +333,7 @@ class MenuModal extends Component {
                       <div className="button-container">
                         <button
                           type="button"
-                          className="grayed" 
+                          className="grayed"
                           onClick={this.handleCloseModal}
                         >
                         Cancel
@@ -332,7 +352,7 @@ class MenuModal extends Component {
         </div>
       </Fragment>
     );
-  } 
+  }
 }
 
 MenuModal.propTypes = {

--- a/client/src/styles/components/_modal.scss
+++ b/client/src/styles/components/_modal.scss
@@ -62,7 +62,7 @@
       }
 
       button {
-        
+
         @include buttons(
           $color-blue,
           $color-white,
@@ -99,7 +99,7 @@
       button:disabled {
         cursor: not-allowed
       }
-      
+
     }
   }
   .form-field-set {
@@ -130,6 +130,9 @@
     font-size: 12px;
     color: $color-red;
     margin-left: 8px;
+  }
+  .errors{
+    float:right;
   }
 }
 

--- a/client/src/tests/components/Admin/Menus/MenuModal.test.js
+++ b/client/src/tests/components/Admin/Menus/MenuModal.test.js
@@ -5,47 +5,47 @@ import MenuModal from '../../../../components/Admin/Menus/MenuModal';
 import { mockMenuItem, menu } from '../../../__mocks__/mockMenuItems';
 import vendorEngagements from '../../../__mocks__/mockEngagements';
 
+const props = {
+  modalButtontext: 'ADD MENU',
+  closeModal: jest.fn(),
+  handleSubmit: jest.fn(),
+  vendorEngagements: [
+    {
+      vendorId: '111',
+      vendor: { name: 'caramel' },
+      startDate: '',
+      endDate: ''
+    }
+  ],
+  mealItems: [
+    {
+      description: "Jollof Rice",
+      id: 1,
+      image: "google.com",
+      isDeleted: false,
+      mealType: "main",
+      name: "Rice"
+    },
+    {
+      description: "Fried Chicken",
+      id: 3,
+      image: "google.com",
+      isDeleted: false,
+      mealType: "protein",
+      name: "Chicken",
+    },
+    {
+      description: "Baked beans",
+      id: 4,
+      image: "google.com",
+      isDeleted: false,
+      mealType: "side",
+      name: "Moi Moi",
+    }
+  ]
+};
 describe('MenuModal Component', () => {
   const setup = () => {
-    const props = {
-      modalButtontext: 'ADD MENU',
-      closeModal: jest.fn(),
-      handleSubmit: jest.fn(),
-      vendorEngagements: [
-        {
-          vendorId: '',
-          vendor: { name: '' },
-          startDate: '',
-          endDate: ''
-        }
-      ],
-      mealItems: [
-        {
-          description: "Jollof Rice",
-          id: 1,
-          image: "google.com",
-          isDeleted: false,
-          mealType: "main",
-          name: "Rice"
-        },
-        {
-          description: "Fried Chicken",
-          id: 3,
-          image: "google.com",
-          isDeleted: false,
-          mealType: "protein",
-          name: "Chicken",
-        },
-        {
-          description: "Baked beans",
-          id: 4,
-          image: "google.com",
-          isDeleted: false,
-          mealType: "side",
-          name: "Moi Moi",
-        }
-      ]
-    };
 
     return mount(<MenuModal {...props} />);
   };
@@ -80,6 +80,38 @@ describe('MenuModal Component', () => {
     const spy = jest.spyOn(wrapper.instance(), 'checkAllowedSelection');
     wrapper.instance().checkAllowedSelection();
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('Should throw error if selected side meal is less that allowedSideMeal', () => {
+    const event = { preventDefault: jest.fn() };
+
+    wrapper.setState({
+      allowedSideMeal: { value: 2 },
+      allowedProtein: { value: 1 },
+      protein: ['Chicken'],
+      sideMeal: ['Moi Moi'],
+      vendorEngagementId: props.vendorEngagements[0].vendorId,
+      mainItem: "Amala",
+    });
+
+    wrapper.instance().formValidation(event);
+    expect(wrapper.instance().state.errors.sideMeal).toEqual('Side meals should not be less than Allowed Side Meal')
+  });
+
+  it('Should throw error if selected protein is less that allowedProten', () => {
+    const event = { preventDefault: jest.fn() };
+
+    wrapper.setState({
+      allowedSideMeal: { value: 1 },
+      allowedProtein: { value: 2 },
+      protein: ['Chicken'],
+      sideMeal: ['Moi Moi'],
+      vendorEngagementId: props.vendorEngagements[0].vendorId,
+      mainItem: "Amala",
+    });
+
+    wrapper.instance().formValidation(event);
+    expect(wrapper.instance().state.errors.protein).toEqual('Proteins not be less than Allowed Protein')
   });
 
   describe('Component methods', () => {


### PR DESCRIPTION
#### What does this PR do?

- Restricts users from adding a menu with sidemeals/proteins that are less than the selected number of allowedSideMeal/allowedProtein

#### Description of Task to be completed?

- Modify MenuModal.js to check if sidemeals/proteins that are not less than the selected number of allowedSideMeal/allowedProtein
- Modify MenuModal.test.js

#### How should this be manually tested?

- Git checkout to this branch
- Login into the app
- Navigate menus.
- Try to add a menu with sidemeals/proteins that are  less than the selected number of allowedSideMeal/allowedProtein

#### What are the relevant pivotal tracker stories?

- [ #166791660](https://www.pivotaltracker.com/story/show/166791660)

#### Background Context

- Currently, the user can add a menu with sidemeals/proteins that are less than the selected number of allowedSideMeal/allowedProtein.

#### Screenshots (If Applicable)
![Jul-08-2019 10-59-28-menu](https://user-images.githubusercontent.com/9887151/60793852-33909300-a171-11e9-85aa-c126def7a6d6.gif)
